### PR TITLE
Fix transient dependencies

### DIFF
--- a/src/Agoda.Builds.Metrics/MeasureBuildTime.cs
+++ b/src/Agoda.Builds.Metrics/MeasureBuildTime.cs
@@ -52,6 +52,10 @@ namespace Agoda.Builds.Metrics
 
                 DevFeedbackPublisher.Publish(ApiEndPoint, data);
             }
+            catch (GitContextNotFoundException)
+            {
+                Log.LogMessage("Unable to get git context. The build time will not be published.");
+            }
             catch (Exception ex)
             {
                 Log.LogMessage("An error occured while capturing the build time: " + ex);

--- a/src/Agoda.Builds.Metrics/MeasureBuildTime.cs
+++ b/src/Agoda.Builds.Metrics/MeasureBuildTime.cs
@@ -52,9 +52,9 @@ namespace Agoda.Builds.Metrics
 
                 DevFeedbackPublisher.Publish(ApiEndPoint, data);
             }
-            catch (GitContextNotFoundException)
+            catch (GitContextNotFoundException ex)
             {
-                Log.LogMessage("Unable to get git context. The build time will not be published.");
+                Log.LogMessage($"The build time will not be published: {ex.Message}");
             }
             catch (Exception ex)
             {

--- a/src/Agoda.DevFeedback.AspNetStartup/Agoda.DevFeedback.AspNetStartup.csproj
+++ b/src/Agoda.DevFeedback.AspNetStartup/Agoda.DevFeedback.AspNetStartup.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Agoda.DevFeedback.AspNetStartup/Agoda.DevFeedback.AspNetStartup.csproj
+++ b/src/Agoda.DevFeedback.AspNetStartup/Agoda.DevFeedback.AspNetStartup.csproj
@@ -1,13 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Agoda.DevFeedback.AspNetStartup/TimedStartupHostedService.cs
+++ b/src/Agoda.DevFeedback.AspNetStartup/TimedStartupHostedService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Agoda.DevFeedback.Common;
 
 namespace Agoda.DevFeedback.AspNetStartup
 {
@@ -39,7 +40,7 @@ namespace Agoda.DevFeedback.AspNetStartup
             {
                 var diff = until.Value - from.Value;
 
-                _logger.LogDebug(
+                _logger.LogInformation(
                     "Application startup time was {duration}ms.",
                     Math.Round(diff.TotalMilliseconds, 0)
                 );
@@ -47,6 +48,10 @@ namespace Agoda.DevFeedback.AspNetStartup
                 try
                 {
                     TimedStartupPublisher.Publish(type: ".AspNetStartup", timeTaken: diff);
+                }
+                catch (GitContextNotFoundException)
+                {
+                    _logger.LogInformation("Unable to get git context. The startup time will not be published.");
                 }
                 catch (Exception ex)
                 {

--- a/src/Agoda.DevFeedback.AspNetStartup/TimedStartupHostedService.cs
+++ b/src/Agoda.DevFeedback.AspNetStartup/TimedStartupHostedService.cs
@@ -49,9 +49,9 @@ namespace Agoda.DevFeedback.AspNetStartup
                 {
                     TimedStartupPublisher.Publish(type: ".AspNetStartup", timeTaken: diff);
                 }
-                catch (GitContextNotFoundException)
+                catch (GitContextNotFoundException ex)
                 {
-                    _logger.LogInformation("Unable to get git context. The startup time will not be published.");
+                    _logger.LogInformation("The startup time will not be published: {reason}", ex.Message);
                 }
                 catch (Exception ex)
                 {

--- a/src/Agoda.DevFeedback.AspNetStartup/TimedStartupMiddleware.cs
+++ b/src/Agoda.DevFeedback.AspNetStartup/TimedStartupMiddleware.cs
@@ -45,9 +45,9 @@ namespace Agoda.DevFeedback.AspNetStartup
                     {
                         TimedStartupPublisher.Publish(type: ".AspNetResponse", timeTaken: diff);
                     }
-                    catch (GitContextNotFoundException)
+                    catch (GitContextNotFoundException ex)
                     {
-                        _logger.LogInformation("Unable to get git context. The startup time until first response will not be published.");
+                        _logger.LogInformation("The startup time until first response will not be published: {reason}", ex.Message);
                     }
                     catch (Exception ex)
                     {

--- a/src/Agoda.DevFeedback.AspNetStartup/TimedStartupMiddleware.cs
+++ b/src/Agoda.DevFeedback.AspNetStartup/TimedStartupMiddleware.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
+using Agoda.DevFeedback.Common;
 
 namespace Agoda.DevFeedback.AspNetStartup
 {
@@ -34,7 +35,7 @@ namespace Agoda.DevFeedback.AspNetStartup
                 {
                     var diff = until.Value - from.Value;
 
-                    _logger.LogDebug(
+                    _logger.LogInformation(
                         "Application startup time until first response was {duration}ms for {path}",
                         Math.Round(diff.TotalMilliseconds, 0),
                         httpContext.Request.Path
@@ -43,6 +44,10 @@ namespace Agoda.DevFeedback.AspNetStartup
                     try
                     {
                         TimedStartupPublisher.Publish(type: ".AspNetResponse", timeTaken: diff);
+                    }
+                    catch (GitContextNotFoundException)
+                    {
+                        _logger.LogInformation("Unable to get git context. The startup time until first response will not be published.");
                     }
                     catch (Exception ex)
                     {

--- a/src/Agoda.DevFeedback.Common/GitContextException.cs
+++ b/src/Agoda.DevFeedback.Common/GitContextException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Agoda.DevFeedback.Common
+{
+    public class GitContextException : Exception
+    {
+        public GitContextException(string message) : base(message)
+        {
+        }
+        
+        public GitContextException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Agoda.DevFeedback.Common/GitContextReader.cs
+++ b/src/Agoda.DevFeedback.Common/GitContextReader.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace Agoda.DevFeedback.Common
 {
     public class GitContextNotFoundException : Exception
     {
+        public GitContextNotFoundException(string message) : base(message)
+        {
+        }
     }
     
     public static class GitContextReader
@@ -13,10 +17,15 @@ namespace Agoda.DevFeedback.Common
         {
             string url = RunCommand("config --get remote.origin.url");
             string branch = RunCommand("rev-parse --abbrev-ref HEAD");
-            
-            if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(branch))
+
+            if (string.IsNullOrEmpty(url))
             {
-                throw new GitContextNotFoundException();
+                throw new GitContextNotFoundException("unable to get git remote url");
+            }
+
+            if (string.IsNullOrEmpty(branch))
+            {
+                throw new GitContextNotFoundException("unable to get git branch");
             }
 
             return new GitContext
@@ -44,7 +53,14 @@ namespace Agoda.DevFeedback.Common
                 }
             };
 
-            process.Start();
+            try
+            {
+                process.Start();
+            }
+            catch(Win32Exception)
+            {
+                throw new GitContextNotFoundException("git executable not found");
+            }
 
             return process.StandardOutput.ReadLine();
         }

--- a/src/Agoda.DevFeedback.Common/GitContextReader.cs
+++ b/src/Agoda.DevFeedback.Common/GitContextReader.cs
@@ -57,9 +57,9 @@ namespace Agoda.DevFeedback.Common
             {
                 process.Start();
             }
-            catch(Win32Exception)
+            catch(Win32Exception ex)
             {
-                throw new GitContextNotFoundException("git executable not found");
+                throw new GitContextNotFoundException($"failed to run git command ({ex.Message})");
             }
 
             return process.StandardOutput.ReadLine();

--- a/src/Agoda.DevFeedback.Common/GitContextReader.cs
+++ b/src/Agoda.DevFeedback.Common/GitContextReader.cs
@@ -3,12 +3,21 @@ using System.Diagnostics;
 
 namespace Agoda.DevFeedback.Common
 {
+    public class GitContextNotFoundException : Exception
+    {
+    }
+    
     public static class GitContextReader
     {
         public static GitContext GetGitContext()
         {
             string url = RunCommand("config --get remote.origin.url");
             string branch = RunCommand("rev-parse --abbrev-ref HEAD");
+            
+            if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(branch))
+            {
+                throw new GitContextNotFoundException();
+            }
 
             return new GitContext
             {

--- a/src/Agoda.DevFeedback.Common/GitContextReader.cs
+++ b/src/Agoda.DevFeedback.Common/GitContextReader.cs
@@ -4,13 +4,6 @@ using System.Diagnostics;
 
 namespace Agoda.DevFeedback.Common
 {
-    public class GitContextNotFoundException : Exception
-    {
-        public GitContextNotFoundException(string message) : base(message)
-        {
-        }
-    }
-    
     public static class GitContextReader
     {
         public static GitContext GetGitContext()
@@ -20,12 +13,12 @@ namespace Agoda.DevFeedback.Common
 
             if (string.IsNullOrEmpty(url))
             {
-                throw new GitContextNotFoundException("unable to get git remote url");
+                throw new GitContextException("Unable to get git remote url.");
             }
 
             if (string.IsNullOrEmpty(branch))
             {
-                throw new GitContextNotFoundException("unable to get git branch");
+                throw new GitContextException("Unable to get git branch.");
             }
 
             return new GitContext
@@ -59,7 +52,7 @@ namespace Agoda.DevFeedback.Common
             }
             catch(Win32Exception ex)
             {
-                throw new GitContextNotFoundException($"failed to run git command ({ex.Message})");
+                throw new GitContextException("Failed to run git command.", ex);
             }
 
             return process.StandardOutput.ReadLine();


### PR DESCRIPTION
- Change `Agoda.DevFeedback.AspNetStartup` to target net6.0 and net7.0
- Add less scary information message when unable to get git context

Before:
![before](https://user-images.githubusercontent.com/1765881/215759264-7756941c-8106-4a5b-9249-65f0e0e0eb4e.png)

After:
![after](https://user-images.githubusercontent.com/1765881/215758568-fac1a4d3-9ad8-47f9-bc15-5168d96f173f.png)
