### PR TITLE
[Refactor] separate Publish<T> function into 2 functions

### DIFF
--- a/src/Agoda.Builds.Metrics/MeasureBuildTime.cs
+++ b/src/Agoda.Builds.Metrics/MeasureBuildTime.cs
@@ -23,11 +23,6 @@ namespace Agoda.Builds.Metrics
         public string EndDateTime { get; set; }
 
         /// <summary>
-        /// Seems not to be set from anywhere.
-        /// </summary>
-        public string ApiEndPoint { get; set; }
-
-        /// <summary>
         /// Set by the Task.Execute method.
         /// Used by the 'CaptureBuildTime' build event.
         /// </summary>
@@ -50,7 +45,7 @@ namespace Agoda.Builds.Metrics
                     gitContext: gitContext
                 );
 
-                DevFeedbackPublisher.Publish(ApiEndPoint, data);
+                DevFeedbackPublisher.PublishBuildData(data);
             }
             catch (GitContextException ex)
             {

--- a/src/Agoda.DevFeedback.AspNetStartup/TimedStartupPublisher.cs
+++ b/src/Agoda.DevFeedback.AspNetStartup/TimedStartupPublisher.cs
@@ -18,7 +18,7 @@ namespace Agoda.DevFeedback.AspNetStartup
                 gitContext: gitContext
             );
 
-            DevFeedbackPublisher.Publish(apiEndpoint: null, result);
+            DevFeedbackPublisher.PublishBuildData(result);
         }
     }
 }

--- a/src/Agoda.DevFeedback.Common/DevFeedbackPublisher.cs
+++ b/src/Agoda.DevFeedback.Common/DevFeedbackPublisher.cs
@@ -7,54 +7,46 @@ namespace Agoda.DevFeedback.Common
 {
     public static class DevFeedbackPublisher
     {
-        public static void Publish<T>(string apiEndpoint, T data)
+        private const string BASE_URL = "http://compilation-metrics/";
+
+        public static void PublishBuildData(object data)
         {
-            Publish(apiEndpoint,data, DevLocalDataType.Build);
+            var targetEndpoint = GetApiEndpoint();
+            var content = new StringContent(JsonSerializer.Serialize(data), Encoding.UTF8, "application/json");
+
+            Send(targetEndpoint, content);
         }
 
-        public static void Publish<T>(string apiEndpoint, T data, DevLocalDataType devLocalDataType)
+        public static void PublishNUnitTestCase(object data)
         {
-            var targetEndpoint = string.Empty;
-            switch (devLocalDataType)
-            {
-                case DevLocalDataType.Build:
-                    targetEndpoint = GetApiEndpoint(apiEndpoint);
-                    break;
-                case DevLocalDataType.NUint:
-                    targetEndpoint = GetNunitApiEndpoint(apiEndpoint);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(devLocalDataType), devLocalDataType, null);
-            }
+            var targetEndpoint = GetNunitApiEndpoint();
+            var content = new StringContent(JsonSerializer.Serialize(data), Encoding.UTF8, "application/json");
+
+            Send(targetEndpoint, content);
+        }
+
+        private static void Send(string endpoint, HttpContent content)
+        {
             using (var httpClient = new HttpClient())
             {
                 httpClient.Timeout = TimeSpan.FromSeconds(2);
 
-                var content = new StringContent(JsonSerializer.Serialize(data), Encoding.UTF8, "application/json");
-                var response = httpClient.PostAsync(targetEndpoint, content).Result;
+                var response = httpClient.PostAsync(endpoint, content).Result;
 
                 response.EnsureSuccessStatusCode();
             }
         }
 
-        private const string BASE_URL = "http://compilation-metrics/";
-        //private const string BASE_URL = "http://localhost:5000/";
-        static string GetApiEndpoint(string apiEndpoint)
+        static string GetApiEndpoint()
         {
-            if (string.IsNullOrEmpty(apiEndpoint))
-            {
-                apiEndpoint = Environment.GetEnvironmentVariable("BUILD_METRICS_ES_ENDPOINT");
-            }
+            var apiEndpoint = Environment.GetEnvironmentVariable("BUILD_METRICS_ES_ENDPOINT");
 
             return string.IsNullOrEmpty(apiEndpoint) ? $"{BASE_URL}dotnet" : apiEndpoint;
         }
 
-        static string GetNunitApiEndpoint(string apiEndpoint)
+        static string GetNunitApiEndpoint()
         {
-            if (string.IsNullOrEmpty(apiEndpoint))
-            {
-                apiEndpoint = Environment.GetEnvironmentVariable("NUNIT_METRICS_ES_ENDPOINT");
-            }
+            var apiEndpoint = Environment.GetEnvironmentVariable("NUNIT_METRICS_ES_ENDPOINT");
 
             return string.IsNullOrEmpty(apiEndpoint) ? $"{BASE_URL}dotnet/nunit" : apiEndpoint;
         }

--- a/src/Agoda.DevFeedback.Common/DevFeedbackPublisher.cs
+++ b/src/Agoda.DevFeedback.Common/DevFeedbackPublisher.cs
@@ -9,7 +9,7 @@ namespace Agoda.DevFeedback.Common
     {
         private const string BASE_URL = "http://compilation-metrics/";
 
-        public static void PublishBuildData(object data)
+        public static void PublishBuildData(DevFeedbackData data)
         {
             var targetEndpoint = GetApiEndpoint();
             var content = new StringContent(JsonSerializer.Serialize(data), Encoding.UTF8, "application/json");

--- a/src/Agoda.DevFeedback.Common/DevLocalDataType.cs
+++ b/src/Agoda.DevFeedback.Common/DevLocalDataType.cs
@@ -1,8 +1,0 @@
-﻿namespace Agoda.DevFeedback.Common
-{
-    public enum DevLocalDataType
-    {
-        Build,
-        NUint
-    }
-}

--- a/src/Agoda.Tests.Metrics.NUnit/AgodaNUnitEventListener.cs
+++ b/src/Agoda.Tests.Metrics.NUnit/AgodaNUnitEventListener.cs
@@ -29,7 +29,7 @@ namespace Agoda.Tests.Metrics.NUnit
                     gitContext,
                     xmlConverter.TestCases
                 );
-                DevFeedbackPublisher.Publish(null, data, DevLocalDataType.NUint);
+                DevFeedbackPublisher.PublishNUnitTestCase(data);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
- Simplify Publish function to allow adding more endpoints without having too much logic in one function
   Instead of:
   ```csharp
      public static void Publish<T>(string apiEndpoint, T data, DevLocalDataType devLocalDataType)
    ```
    changes this:
    ```csharp
       public static void PublishBuildData(DevFeedbackData data)
       public static void PublishNUnitTestCase(object data) // this function should have strong type data
   ```
- Remove unused property (MeasureBuildTime.ApiEndpoint)