### PR TITLE
[BUG] use Newtonsoft instead of System.Text.Json to allow vstest.console and nunit3-console loading this extension on some enviroments

### DIFF
--- a/src/Agoda.DevFeedback.Common/Agoda.DevFeedback.Common.csproj
+++ b/src/Agoda.DevFeedback.Common/Agoda.DevFeedback.Common.csproj
@@ -6,8 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <InternalsVisibleTo Include="Agoda.DevFeedback.Common.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Agoda.DevFeedback.Common/DevFeedbackData.cs
+++ b/src/Agoda.DevFeedback.Common/DevFeedbackData.cs
@@ -1,50 +1,50 @@
 ﻿using System;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Agoda.DevFeedback.Common
 {
     public class DevFeedbackData
     {
-        [JsonPropertyName("id")]
+        [JsonProperty("id")]
         public Guid Id { get; set; }
         
-        [JsonPropertyName("metricsVersion")]
+        [JsonProperty("metricsVersion")]
         public string MetricsVersion { get; set; }
         
-        [JsonPropertyName("userName")]
+        [JsonProperty("userName")]
         public string UserName { get; set; }
         
-        [JsonPropertyName("cpuCount")]
+        [JsonProperty("cpuCount")]
         public int CpuCount { get; set; }
         
-        [JsonPropertyName("hostname")]
+        [JsonProperty("hostname")]
         public string Hostname { get; set; }
         
-        [JsonPropertyName("platform")]
+        [JsonProperty("platform")]
         public PlatformID Platform { get; set; }
         
-        [JsonPropertyName("os")]
+        [JsonProperty("os")]
         public string Os { get; set; }
         
-        [JsonPropertyName("timeTaken")]
+        [JsonProperty("timeTaken")]
         public string TimeTaken { get; set; }
         
-        [JsonPropertyName("branch")]
+        [JsonProperty("branch")]
         public string Branch { get; set; }
         
-        [JsonPropertyName("type")]
+        [JsonProperty("type")]
         public string Type { get; set; }
         
-        [JsonPropertyName("projectName")]
+        [JsonProperty("projectName")]
         public string ProjectName { get; set; }
         
-        [JsonPropertyName("repository")]
+        [JsonProperty("repository")]
         public string Repository { get; set; }
         
-        [JsonPropertyName("repositoryName")]
+        [JsonProperty("repositoryName")]
         public string RepositoryName { get; set; }
         
-        [JsonPropertyName("date")]
+        [JsonProperty("date")]
         public DateTime Date { get; set; }
 
         public DevFeedbackData(

--- a/src/Agoda.DevFeedback.Common/DevFeedbackPublisher.cs
+++ b/src/Agoda.DevFeedback.Common/DevFeedbackPublisher.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
-using System.Text.Json;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Agoda.DevFeedback.Common
 {
@@ -46,7 +46,7 @@ namespace Agoda.DevFeedback.Common
             using (var httpClient = new HttpClient())
             {
                 httpClient.Timeout = TimeSpan.FromSeconds(2);
-                var content = new StringContent(JsonSerializer.Serialize(data), Encoding.UTF8, "application/json");
+                var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json");
                 var response = await httpClient.PostAsync(targetEndpoint, content);
                 response.EnsureSuccessStatusCode();
             }

--- a/src/Agoda.DevFeedback.CommonTests/Agoda.DevFeedback.Common.Tests.csproj
+++ b/src/Agoda.DevFeedback.CommonTests/Agoda.DevFeedback.Common.Tests.csproj
@@ -15,7 +15,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NSubstitute" Version="4.2.2" />
 		<PackageReference Include="nunit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />

--- a/src/Agoda.Tests.Metrics.NUnit.Tests/Agoda.Tests.Metrics.NUnit.Tests.csproj
+++ b/src/Agoda.Tests.Metrics.NUnit.Tests/Agoda.Tests.Metrics.NUnit.Tests.csproj
@@ -16,7 +16,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NSubstitute" Version="4.2.2" />
 		<PackageReference Include="nunit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />


### PR DESCRIPTION
Since we target .netstandard2.0 which doesn't have System.Text.Json. Adding it as dependencies cause some problems on user machine. As this library is dependent on .Net version, some machines may experience loading DLL error for this library or its dependencies.

To prevent this problem, using third-party library will make sure that it' will not collide with the runtime library.