### PR TITLE
[Bug] wrong endpoint for sending build time

### DIFF
--- a/src/Agoda.Builds.Metrics/MeasureBuildTime.cs
+++ b/src/Agoda.Builds.Metrics/MeasureBuildTime.cs
@@ -50,7 +50,7 @@ namespace Agoda.Builds.Metrics
                     gitContext: gitContext
                 );
 
-                DevFeedbackPublisher.Publish(ApiEndPoint, data, DevLocalDataType.NUnit);
+                DevFeedbackPublisher.Publish(ApiEndPoint, data, DevLocalDataType.Build);
             }
             catch (GitContextException ex)
             {


### PR DESCRIPTION
Bug: Publish build time to test metrics endpoint
Fix: Update the publish type to be `Build`