### PR TITLE
[Bug] Publich timeout=2sec is too short

### DIFF
--- a/src/Agoda.DevFeedback.Common/DevFeedbackPublisher.cs
+++ b/src/Agoda.DevFeedback.Common/DevFeedbackPublisher.cs
@@ -45,7 +45,6 @@ namespace Agoda.DevFeedback.Common
             var targetEndpoint = GetApiEndpoint(devLocalDataType, apiEndpoint);
             using (var httpClient = new HttpClient())
             {
-                httpClient.Timeout = TimeSpan.FromSeconds(2);
                 var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json");
                 var response = await httpClient.PostAsync(targetEndpoint, content);
                 response.EnsureSuccessStatusCode();


### PR DESCRIPTION
Problem: Timeout = 2sec is too short for some environment to send test metric
Fix:  Remove this setting first and use default timeout (100sec)

Error:
```
System.AggregateException: One or more errors occurred. ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at Agoda.DevFeedback.Common.DevFeedbackPublisher.Publish(String apiEndpoint, Object data, DevLocalDataType devLocalDataType)
   at Agoda.Tests.Metrics.NUnit.AgodaNUnitEventListener.OnTestEvent(String report)
---> (Inner Exception #0) System.Threading.Tasks.TaskCanceledException: A task was canceled.<---
```
